### PR TITLE
Update NServiceBus dependency version

### DIFF
--- a/packaging/nuget/NServiceBus.SimpleInjector.nuspec
+++ b/packaging/nuget/NServiceBus.SimpleInjector.nuspec
@@ -14,7 +14,7 @@
     <description>Adapter for the SimpleInjector IoC Container</description>
     <releaseNotes></releaseNotes>
     <dependencies>
-      <dependency id="NServiceBus" version="[6.0.0,8.0.0)" />
+      <dependency id="NServiceBus" version="[7.0.0,8.0.0)" />
       <dependency id="SimpleInjector" version="[4.0.0, 5.0.0)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
The dependencies for version 3.0.1 say it works with version >= 6.0.0 of NServiceBus, however with NServiceBus 6.5.4 installed, it causes the below build error:

`Assembly 'NServiceBus.SimpleInjector' with identity 'NServiceBus.SimpleInjector, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null' uses 'NServiceBus.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c' which has a higher version than referenced assembly 'NServiceBus.Core' with identity 'NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c'`

I've updated the nuspec file to require a minimum NServiceBus version of 7.0.0.