### PR TITLE
Updated SimpleInjector to version 5.0.3 in nuspec

### DIFF
--- a/packaging/nuget/NServiceBus.SimpleInjector.nuspec
+++ b/packaging/nuget/NServiceBus.SimpleInjector.nuspec
@@ -3,7 +3,7 @@
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>NServiceBus.SimpleInjector</id>
     <title>NServiceBus SimpleInjector</title>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <authors>WilliamBZA</authors>
     <owners>WilliamBZA</owners>
     <license type="expression">MIT</license>
@@ -15,7 +15,7 @@
     <releaseNotes></releaseNotes>
     <dependencies>
       <dependency id="NServiceBus" version="[7.0.0,8.0.0)" />
-      <dependency id="SimpleInjector" version="[4.0.0, 5.0.0)" />
+      <dependency id="SimpleInjector" version="[4.0.0, 5.0.3]" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NServiceBus.SimpleInjector/NServiceBus.SimpleInjector.csproj
+++ b/src/NServiceBus.SimpleInjector/NServiceBus.SimpleInjector.csproj
@@ -7,8 +7,8 @@
     <Company>NServiceBus Ltd.</Company>
     <Copyright>Copyright NServiceBus. All rights reserved</Copyright>
     <Description>Implementation of container functionality on top of SimpleInjector.</Description>
-    <AssemblyVersion>3.0.2.0</AssemblyVersion>
-    <Version>3.0.2</Version>
+    <AssemblyVersion>3.0.6.0</AssemblyVersion>
+    <Version>3.0.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SimpleInjector" Version="4.3.0" />
+    <PackageReference Include="SimpleInjector" Version="5.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.SimpleInjector/SimpleInjectorObjectBuilder.cs
+++ b/src/NServiceBus.SimpleInjector/SimpleInjectorObjectBuilder.cs
@@ -33,6 +33,8 @@ namespace NServiceBus.ObjectBuilder.SimpleInjector
             container.Options.AllowOverridingRegistrations = true;
             container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
             container.Options.AutoWirePropertiesImplicitly();
+            // Without this the InstancePerCall component cannot be registered because it is an IDisposable
+            container.Options.EnableAutoVerification = false;
 
             AsyncScopedLifestyle.BeginScope(container);
         }


### PR DESCRIPTION
Set EnableAutoVerification to false because otherwise the unit tests will fail with registering an InstancePerCall component. It implements IDisposable and should therefore not be registered as Transient